### PR TITLE
Added error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,7 +33,12 @@ app.use(express.static('static'));
 /* Send all calls to /model/* to the same route on the model endpoint
    and return the results returned by the model */
 app.all('/model/:route', function(req, res) {
-  req.pipe(request(args.model + req.path)).pipe(res);
+  req.pipe(request(args.model + req.path))
+    .on('error', function(err) {
+      console.error(err);
+      res.status(500).send('Error connecting to the model microservice');
+    })
+    .pipe(res);
 });
 
 app.listen(args.port);

--- a/static/js/webapp.js
+++ b/static/js/webapp.js
@@ -155,7 +155,7 @@ $(function() {
           }
         },
         error: function(jqXHR, status, error) {
-          alert('Object Detection Failed: ' + error);
+          alert('Object Detection Failed: ' + jqXHR.responseText);
         },
         complete: function() {
           // Re-enable upload button


### PR DESCRIPTION
Previously if the model microservice was not running the web app would surface a vague error then die.

Now the app surfaces a actionable error (start the mircoservice) and stays running, connecting to the microservice once it's up.